### PR TITLE
CFY-4607 make the tests that create keypairs on openstack, delete them

### DIFF
--- a/system_tests/centos_base.py
+++ b/system_tests/centos_base.py
@@ -80,6 +80,14 @@ class CentosBase(object):
     def iaas_url(self):
         return self.bootstrap_inputs['keystone_url']
 
+    def additional_setup(self):
+        self.local_env = None
+        self.addCleanup(self._remove_keypairs)
+        super(CentosBase, self).additional_setup()
+
+    def _remove_keypairs(self):
+        self.env.handler.remove_keypairs_from_local_env(self.local_env)
+
 
 class Centos7Base(CentosBase):
 


### PR DESCRIPTION
the centos tests use openstack and create keypairs as part of their
blueprint - make sure they also delete the keypair in their cleanup.

This is needed because the openstack handler doesn't remove keypairs
automatically, as it does with other kinds of resources.