### PR TITLE
allows bootstrap to not validate memory, which is problematic for m3.medium instances we use for testing.

### DIFF
--- a/system_tests/centos_base.py
+++ b/system_tests/centos_base.py
@@ -44,6 +44,7 @@ class CentosBase(object):
     def bootstrap_inputs(self):
         return {
             'keystone_username': self.env.keystone_username,
+            'ignore_bootstrap_validations': 'true',
             'keystone_password': self.env.keystone_password,
             'keystone_tenant_name': self.env.keystone_tenant_name,
             'keystone_url': self.env.keystone_url,

--- a/system_tests/rhel_base.py
+++ b/system_tests/rhel_base.py
@@ -53,6 +53,7 @@ class RHELBase(object):
             'manager_keypair_name': '{0}-manager-keypair'.format(self.prefix),
             'agent_keypair_name': '{0}-agent-keypair'.format(self.prefix),
             'ssh_user': self.env.rhel_7_image_user,
+            'ignore_bootstrap_validations': 'true',
             'agents_user': self.env.rhel_7_image_user,
             'image_id': self.env.rhel_7_image_id,
             'instance_type': self.env.medium_instance_type,

--- a/system_tests/test_windows_bootstrap.py
+++ b/system_tests/test_windows_bootstrap.py
@@ -86,6 +86,7 @@ class TestWindowsBase(TestCliPackage):
             'manager_keypair_name': '{0}-manager-keypair'.format(self.prefix),
             'agent_keypair_name': '{0}-agent-keypair'.format(self.prefix),
             'ssh_user': 'centos',
+            'ignore_bootstrap_validations': 'true',
             'agents_user': 'centos',
             'image_id': self.env.centos_7_image_id,
             'instance_type': self.env.medium_instance_type,

--- a/system_tests/ubuntu_base.py
+++ b/system_tests/ubuntu_base.py
@@ -52,6 +52,7 @@ class UbuntuBase(object):
             'ec2_region_name': self.env.ec2_region_name,
             'manager_keypair_name': '{0}-manager-keypair'.format(self.prefix),
             'agent_keypair_name': '{0}-agent-keypair'.format(self.prefix),
+            'ignore_bootstrap_validations': 'true',
             'ssh_user': self.env.rhel_7_image_user,
             'agents_user': self.env.rhel_7_image_user,
             'image_id': self.env.rhel_7_image_id,


### PR DESCRIPTION
allows bootstrap to not validate memory, which is problematic for m3.medium instances we use for testing.